### PR TITLE
Enforce stronger password policy (12+ chars)

### DIFF
--- a/App/src/Validator/FormValidator.php
+++ b/App/src/Validator/FormValidator.php
@@ -150,7 +150,7 @@ abstract class FormValidator
         $hasLowercase = preg_match('/[a-z]/', $password);
         $hasDigit     = preg_match('/[0-9]/', $password);
 
-        $hasSpecialChar = preg_match('#[!"#$%&\'()*+,\-./:;<=>?@[\\\\\]^_`{|}~£€§µ°]#u', $password);
+        $hasSpecialChar = preg_match('/[\W_]/u', $password);
         return $hasUppercase && $hasLowercase && $hasDigit && $hasSpecialChar;
     }
 

--- a/App/src/Validator/FormValidator.php
+++ b/App/src/Validator/FormValidator.php
@@ -143,7 +143,15 @@ abstract class FormValidator
      */
     protected function isValidPassword(string $password): bool
     {
-        return strlen($password) >= 8;
+        if (mb_strlen($password) < 12) {
+            return false;
+        }
+        $hasUppercase = preg_match('/[A-Z]/', $password);
+        $hasLowercase = preg_match('/[a-z]/', $password);
+        $hasDigit     = preg_match('/[0-9]/', $password);
+
+        $hasSpecialChar = preg_match('#[!"#$%&\'()*+,\-./:;<=>?@[\\\\\]^_`{|}~£€§µ°]#u', $password);
+        return $hasUppercase && $hasLowercase && $hasDigit && $hasSpecialChar;
     }
 
     /**

--- a/App/src/Validator/ResetPasswordValidator.php
+++ b/App/src/Validator/ResetPasswordValidator.php
@@ -49,7 +49,8 @@ class ResetPasswordValidator extends FormValidator
             throw new ExceptionValidationResetPassword(
                 'pwdnew',
                 'Not Valid',
-                "Le mot de passe doit contenir au moins 8 caractères."
+                "Obligation de 12 caractères minimum avec une majuscule, une minuscule, 
+                            un chiffre et un caractère spéciale."
             );
         }
         if (($data['pwdnew'] ?? '') !== ($data['pwdverif'] ?? '')) {

--- a/App/src/Validator/ResetPasswordValidator.php
+++ b/App/src/Validator/ResetPasswordValidator.php
@@ -50,7 +50,7 @@ class ResetPasswordValidator extends FormValidator
                 'pwdnew',
                 'Not Valid',
                 "Obligation de 12 caractères minimum avec une majuscule, une minuscule, 
-                            un chiffre et un caractère spéciale."
+                            un chiffre et un caractère spécial."
             );
         }
         if (($data['pwdnew'] ?? '') !== ($data['pwdverif'] ?? '')) {

--- a/App/src/Validator/ValidationServiceRegister.php
+++ b/App/src/Validator/ValidationServiceRegister.php
@@ -69,7 +69,8 @@ class ValidationServiceRegister extends FormValidator
             $errors[] = new ExceptionValidationRegister(
                 "password",
                 "string",
-                "Mot de passe trop court (min 8 caractères)."
+                "Obligation de 12 caractères minimum avec une majuscule, une minuscule, 
+                            un chiffre et un caractère spéciale pour le mot de passe."
             );
         }
 

--- a/App/src/Views/User/register.html
+++ b/App/src/Views/User/register.html
@@ -116,13 +116,14 @@
                         type="password"
                         id="password"
                         name="password"
-                        minlength="8"
+                        minlength="12"
                         autocomplete="new-password"
                         aria-describedby="pwd-desc">
-                <small id="pwd-desc">Au moins 8 caractères</small>
+                <small id="pwd-desc">Au moins 12 caractères</small>
 
                 <label for="passwordverif">
                     Confirmer le mot de passe
+                    <abbr title="requis" >*</abbr>
                     <abbr title="requis" >*</abbr>
                 </label>
                 <input
@@ -130,7 +131,7 @@
                         type="password"
                         id="passwordverif"
                         name="passwordverif"
-                        minlength="8"
+                        minlength="12"
                         autocomplete="new-password"
                 >
             </article>

--- a/App/src/Views/pwd/reset-password.html
+++ b/App/src/Views/pwd/reset-password.html
@@ -15,7 +15,7 @@
             type="password"
             id="pwdnew"
             name="pwdnew"
-            minlength="8"
+            minlength="12"
             autocomplete="new-password"
     >
 
@@ -28,7 +28,7 @@
             type="password"
             id="pwdverif"
             name="pwdverif"
-            minlength="8"
+            minlength="12"
             autocomplete="new-password"
     >
   </fieldset>

--- a/App/tests/Unit/Utilis/Validator/ValidationServiceRegisterTest.php
+++ b/App/tests/Unit/Utilis/Validator/ValidationServiceRegisterTest.php
@@ -44,8 +44,8 @@ class ValidationServiceRegisterTest extends TestCase
             'last_name' => 'Dupont',
             'user_type' => 'student',
             'email' => 'jean.dupont',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecurePass123@',
+            'passwordverif' => 'SecurePass123@',
             'phone' => '0612345678',
             'year' => '2',
             'major' => 'A',
@@ -108,8 +108,8 @@ class ValidationServiceRegisterTest extends TestCase
         $this->expectException(ExceptionValidationRegisters::class);
 
         $data = $this->getValidBaseData();
-        $data['password'] = 'Password123';
-        $data['passwordverif'] = 'DifferentPass123';
+        $data['password'] = 'ValidP@ssword123!';
+        $data['passwordverif'] = 'DiffP@ssword456!';
 
         $escaped = $this->validator->escape($data);
         $this->validator->validate($escaped);
@@ -215,8 +215,8 @@ class ValidationServiceRegisterTest extends TestCase
             'last_name' => 'Dupont',
             'user_type' => 'professor',
             'email' => 'jean.dupont',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecurePass1234!',
+            'passwordverif' => 'SecurePass1234!',
             'phone' => '0612345678',
             'terms' => 'on'
         ];

--- a/App/tests/Unit/Utilis/Validator/ValidatorTest.php
+++ b/App/tests/Unit/Utilis/Validator/ValidatorTest.php
@@ -44,8 +44,8 @@ class ValidatorTest extends TestCase
         $validator = new LoginValidator();
         $data = $validator->escape(
             [
-            'email' => 'test@univ-amu.fr',
-            'password' => 'password123'
+                'email' => 'test@univ-amu.fr',
+                'password' => 'password123@'
             ]
         );
 
@@ -60,8 +60,8 @@ class ValidatorTest extends TestCase
         $validator = new LoginValidator();
         $validator->escape(
             [
-            'email' => '',
-            'password' => ''
+                'email' => '',
+                'password' => ''
             ]
         );
     }
@@ -75,8 +75,8 @@ class ValidatorTest extends TestCase
         $validator = new LoginValidator();
         $data = $validator->escape(
             [
-            'email' => $email,
-            'password' => 'password123'
+                'email' => $email,
+                'password' => 'password123'
             ]
         );
 
@@ -102,8 +102,8 @@ class ValidatorTest extends TestCase
         $validator = new LoginValidator();
         $data = $validator->escape(
             [
-            'email' => 'test<script>alert("xss")</script>@test.fr',
-            'password' => '<b>password</b>'
+                'email' => 'test<script>alert("xss")</script>@test.fr',
+                'password' => '<b>password</b>'
             ]
         );
 
@@ -122,8 +122,8 @@ class ValidatorTest extends TestCase
         $validator = new ResetPasswordValidator();
         $data = $validator->escape(
             [
-            'pwdnew' => 'NewPassword123',
-            'pwdverif' => 'NewPassword123'
+                'pwdnew' => 'NewPassword123@',
+                'pwdverif' => 'NewPassword123@'
             ]
         );
 
@@ -134,13 +134,13 @@ class ValidatorTest extends TestCase
     public function resetPasswordValidatorRejectsShortPassword(): void
     {
         $this->expectException(ExceptionValidationResetPassword::class);
-        $this->expectExceptionMessage('au moins 8 caractères');
+        $this->expectExceptionMessage('Obligation de 12 caractères minimum');
 
         $validator = new ResetPasswordValidator();
         $data = $validator->escape(
             [
-            'pwdnew' => 'short',
-            'pwdverif' => 'short'
+                'pwdnew' => 'Short1!',
+                'pwdverif' => 'Short1!'
             ]
         );
 
@@ -156,8 +156,8 @@ class ValidatorTest extends TestCase
         $validator = new ResetPasswordValidator();
         $data = $validator->escape(
             [
-            'pwdnew' => 'Password123',
-            'pwdverif' => 'DifferentPassword123'
+                'pwdnew' => 'Password123!',
+                'pwdverif' => 'DifferentPassword123!'
             ]
         );
 
@@ -173,8 +173,8 @@ class ValidatorTest extends TestCase
         $validator = new ResetPasswordValidator();
         $data = $validator->escape(
             [
-            'pwdnew' => $password,
-            'pwdverif' => $password
+                'pwdnew' => $password,
+                'pwdverif' => $password
             ]
         );
 
@@ -184,12 +184,10 @@ class ValidatorTest extends TestCase
     public static function validPasswordsProvider(): array
     {
         return [
-            'exactly_8_chars' => ['12345678'],
-            'with_special' => ['P@ssw0rd!'],
-            'long_password' => ['ThisIsAVeryLongPasswordWithMoreThan20Characters'],
-            'with_spaces' => ['My Pass Word 123'],
-            'numbers_only' => ['12345678'],
-            'mixed_case' => ['AbCdEfGh']
+            'exactly_12_chars' => ['Password123!'],
+            'with_special' => ['P@ssw0rd2026!'],
+            'long_password' => ['ThisIsAVeryLongPasswordWithMoreThan20Characters1!'],
+            'with_spaces' => ['My P@ss Word 123']
         ];
     }
 
@@ -201,8 +199,8 @@ class ValidatorTest extends TestCase
         $validator = new ResetPasswordValidator();
         $validator->escape(
             [
-            'pwdnew' => '',
-            'pwdverif' => ''
+                'pwdnew' => '',
+                'pwdverif' => ''
             ]
         );
     }
@@ -218,7 +216,7 @@ class ValidatorTest extends TestCase
         $validator = new ForgotPasswordValidator();
         $data = $validator->escape(
             [
-            'email' => 'test@univ-amu.fr'
+                'email' => 'test@univ-amu.fr'
             ]
         );
 
@@ -233,7 +231,7 @@ class ValidatorTest extends TestCase
         $validator = new ForgotPasswordValidator();
         $data = $validator->escape(
             [
-            'email' => 'not-an-email'
+                'email' => 'not-an-email'
             ]
         );
 
@@ -252,7 +250,7 @@ class ValidatorTest extends TestCase
         $validator = new ForgotPasswordValidator();
         $data = $validator->escape(
             [
-            'email' => 'test@univ-amu.fr'
+                'email' => 'test@univ-amu.fr'
             ]
         );
 
@@ -272,7 +270,7 @@ class ValidatorTest extends TestCase
         $validator = new ForgotPasswordValidator();
         $data = $validator->escape(
             [
-            'email' => 'test@univ-amu.fr'
+                'email' => 'test@univ-amu.fr'
             ]
         );
 
@@ -488,8 +486,8 @@ class ValidatorTest extends TestCase
 
         $data = $validator->escape(
             [
-            'pwdnew' => 'Pàsswørd123',
-            'pwdverif' => 'Pàsswørd123'
+                'pwdnew' => 'Pàsswørd1234!',
+                'pwdverif' => 'Pàsswørd1234!'
             ]
         );
 
@@ -508,8 +506,8 @@ class ValidatorTest extends TestCase
 
         $data = $validator->escape(
             [
-            'email' => $longEmail,
-            'password' => $longPassword
+                'email' => $longEmail,
+                'password' => $longPassword
             ]
         );
 


### PR DESCRIPTION
Strengthen password requirements across validation and UI: FormValidator now requires a minimum of 12 characters and enforces at least one uppercase, one lowercase, one digit, and one special character (via regex). Update validators' error messages (ResetPasswordValidator, ValidationServiceRegister) to reflect the new policy. Update client-side constraints and helper text in registration and reset-password views (minlength attributes set to 12 and copy updated to indicate 12 characters).