### PR TITLE
Require 12-char complex passwords

### DIFF
--- a/App/src/Validator/FormValidator.php
+++ b/App/src/Validator/FormValidator.php
@@ -144,7 +144,15 @@ abstract class FormValidator
      */
     protected function isValidPassword(string $password): bool
     {
-        return strlen($password) >= 8;
+        if (mb_strlen($password) < 12) {
+            return false;
+        }
+        $hasUppercase = preg_match('/[A-Z]/', $password);
+        $hasLowercase = preg_match('/[a-z]/', $password);
+        $hasDigit     = preg_match('/[0-9]/', $password);
+
+        $hasSpecialChar = preg_match('/[\W_]/u', $password);
+        return $hasUppercase && $hasLowercase && $hasDigit && $hasSpecialChar;
     }
 
     /**

--- a/App/src/Validator/ResetPassword/ResetPasswordValidator.php
+++ b/App/src/Validator/ResetPassword/ResetPasswordValidator.php
@@ -50,7 +50,8 @@ class ResetPasswordValidator extends FormValidator
             throw new ExceptionValidationResetPassword(
                 'pwdnew',
                 'Not Valid',
-                "Le mot de passe doit contenir au moins 8 caractères."
+                "Obligation de 12 caractères minimum avec une majuscule, une minuscule, 
+                            un chiffre et un caractère spécial."
             );
         }
         if (($data['pwdnew'] ?? '') !== ($data['pwdverif'] ?? '')) {

--- a/App/src/Views/Password/reset-password.html
+++ b/App/src/Views/Password/reset-password.html
@@ -15,7 +15,7 @@
             type="password"
             id="pwdnew"
             name="pwdnew"
-            minlength="8"
+            minlength="12"
             autocomplete="new-password"
     >
 
@@ -28,7 +28,7 @@
             type="password"
             id="pwdverif"
             name="pwdverif"
-            minlength="8"
+            minlength="12"
             autocomplete="new-password"
     >
   </fieldset>

--- a/App/src/Views/User/register.html
+++ b/App/src/Views/User/register.html
@@ -121,10 +121,10 @@
                         type="password"
                         id="password"
                         name="password"
-                        minlength="8"
+                        minlength="12"
                         autocomplete="new-password"
                     aria-describedby="pwd-desc">
-                <small id="pwd-desc">Au moins 8 caractères</small>
+                <small id="pwd-desc">Obligation de 12 caractères minimum avec une majuscule, une minuscule et un caractère spécial</small>
 
                 <label for="passwordverif">
                     Confirmer le mot de passe
@@ -135,7 +135,7 @@
                         type="password"
                         id="passwordverif"
                         name="passwordverif"
-                        minlength="8"
+                        minlength="12"
                         autocomplete="new-password"
                 >
             </article>

--- a/App/tests/Unit/Validator/Register/ValidationServiceRegisterExtendedTest.php
+++ b/App/tests/Unit/Validator/Register/ValidationServiceRegisterExtendedTest.php
@@ -72,8 +72,8 @@ class ValidationServiceRegisterExtendedTest extends TestCase
         $this->expectException(ExceptionValidationRegisters::class);
 
         $data = $this->getValidStudentData();
-        $data['password'] = 'Password123';
-        $data['passwordverif'] = 'DifferentPass456';
+        $data['password'] = 'ValidP@ss1234!';
+        $data['passwordverif'] = 'DiffP@ss5678!';
 
         $escaped = $this->validator->escape($data);
         $this->validator->validate($escaped);
@@ -278,8 +278,8 @@ class ValidationServiceRegisterExtendedTest extends TestCase
             'last_name' => 'Dupont',
             'user_type' => 'professor',
             'email' => 'prof.dupont',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecureP@ss2026!',
+            'passwordverif' => 'SecureP@ss2026!',
             'phone' => '0612345678',
             'terms' => 'on',
             'h-captcha-response' => 'test-captcha-success'
@@ -300,8 +300,8 @@ class ValidationServiceRegisterExtendedTest extends TestCase
             'last_name' => 'Martin',
             'user_type' => 'client',
             'email' => 'client.martin@univ-amu.fr',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecureP@ss2026!',
+            'passwordverif' => 'SecureP@ss2026!',
             'phone' => '0612345678',
             'organisation' => 'Ma Société',
             'terms' => 'on',
@@ -345,8 +345,8 @@ class ValidationServiceRegisterExtendedTest extends TestCase
                     'last_name' => 'Dupont',
                         'user_type' => 'student',
                             'email' => 'jean.dupont@etu.univ-amu.fr',
-                                'password' => 'SecurePass123',
-                                    'passwordverif' => 'SecurePass123',
+                                'password' => 'SecureP@ss2026!',
+                                    'passwordverif' => 'SecureP@ss2026!',
                                         'phone' => '0612345678',
                                             'year' => '1',
                                                 'td' => 'TD1',
@@ -382,8 +382,8 @@ class ValidationServiceRegisterExtendedTest extends TestCase
             'last_name' => 'Dupont',
             'user_type' => 'student',
             'email' => 'jean.dupont',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecureP@ss2026!',
+            'passwordverif' => 'SecureP@ss2026!',
             'phone' => '0612345678',
             'year' => '1',
             'td' => 'TD1',

--- a/App/tests/Unit/Validator/Register/ValidationServiceRegisterTest.php
+++ b/App/tests/Unit/Validator/Register/ValidationServiceRegisterTest.php
@@ -44,8 +44,8 @@ class ValidationServiceRegisterTest extends TestCase
             'last_name' => 'Dupont',
             'user_type' => 'student',
             'email' => 'jean.dupont',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecureP@ss2026!',
+            'passwordverif' => 'SecureP@ss2026!',
             'phone' => '0612345678',
             'year' => '2',
             'major' => 'A',
@@ -109,8 +109,8 @@ class ValidationServiceRegisterTest extends TestCase
         $this->expectException(ExceptionValidationRegisters::class);
 
         $data = $this->getValidBaseData();
-        $data['password'] = 'Password123';
-        $data['passwordverif'] = 'DifferentPass123';
+        $data['password'] = 'ValidP@ssword123!';
+        $data['passwordverif'] = 'DiffP@ssword456!';
 
         $escaped = $this->validator->escape($data);
         $this->validator->validate($escaped);
@@ -216,8 +216,8 @@ class ValidationServiceRegisterTest extends TestCase
             'last_name' => 'Dupont',
             'user_type' => 'professor',
             'email' => 'jean.dupont',
-            'password' => 'SecurePass123',
-            'passwordverif' => 'SecurePass123',
+            'password' => 'SecureP@ss2026!',
+            'passwordverif' => 'SecureP@ss2026!',
             'phone' => '0612345678',
             'terms' => 'on',
             'h-captcha-response' => 'test-captcha-success'

--- a/App/tests/Unit/Validator/ResetPassword/ResetPasswordValidatorTest.php
+++ b/App/tests/Unit/Validator/ResetPassword/ResetPasswordValidatorTest.php
@@ -48,10 +48,10 @@ class ResetPasswordValidatorTest extends TestCase
     public static function validPasswordsProvider(): array
     {
         return [
-            'eight_chars' => ['12345678', '12345678'],
-            'long_password' => ['ThisIsAVeryLongPassword123456', 'ThisIsAVeryLongPassword123456'],
+            'exactly_12_chars' => ['Valid12Chars!', 'Valid12Chars!'],
+            'long_password' => ['ThisIsAVeryLongPassword123456!', 'ThisIsAVeryLongPassword123456!'],
             'with_special_chars' => ['Pass@word123!', 'Pass@word123!'],
-            'mixed_case' => ['AbCdEfGh', 'AbCdEfGh']
+            'mixed_case_complex' => ['MixedCase123@', 'MixedCase123@']
         ];
     }
 
@@ -100,8 +100,8 @@ class ResetPasswordValidatorTest extends TestCase
         $this->expectException(ExceptionValidationResetPassword::class);
 
         $data = [
-            'pwdnew' => 'Password123',
-            'pwdverif' => 'DifferentPass456'
+            'pwdnew' => 'P@ssword2026!',
+            'pwdverif' => 'DifferentP@ssword2026!'
         ];
 
         $escaped = $this->validator->escape($data);
@@ -111,10 +111,10 @@ class ResetPasswordValidatorTest extends TestCase
     public static function mismatchedPasswordsProvider(): array
     {
         return [
-            'different_length' => ['12345678', '123456789'],
-            'different_case' => ['PASSWORD', 'password'],
-            'trailing_space' => ['password ', 'password'],
-            'leading_space' => [' password', 'password']
+            'different_length' => ['ValidP@ss123!', 'ValidP@ss1234!'],
+            'different_case' => ['ValidP@ss123!', 'validp@ss123!'],
+            'trailing_space' => ['ValidP@ss123! ', 'ValidP@ss123!'],
+            'leading_space' => [' ValidP@ss123!', 'ValidP@ss123!']
         ];
     }
 
@@ -194,8 +194,8 @@ class ResetPasswordValidatorTest extends TestCase
     {
         try {
             $data = [
-                'pwdnew' => 'ValidPassword123',
-                'pwdverif' => 'DifferentPassword456'
+                'pwdnew' => 'ValidP@ssword123!',
+                'pwdverif' => 'DifferentP@ssword456!'
             ];
 
             $escaped = $this -> validator -> escape($data);

--- a/App/tests/Unit/Validator/ResetPassword/ResetPasswordValidatorTest.php
+++ b/App/tests/Unit/Validator/ResetPassword/ResetPasswordValidatorTest.php
@@ -37,8 +37,8 @@ class ResetPasswordValidatorTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         $data = [
-            'pwdnew' => 'SecurePass123',
-            'pwdverif' => 'SecurePass123'
+            'pwdnew' => 'SecureP@ss1234!',
+            'pwdverif' => 'SecureP@ss1234!'
         ];
 
         $escaped = $this->validator->escape($data);

--- a/App/tests/Unit/Validator/ValidatorTest.php
+++ b/App/tests/Unit/Validator/ValidatorTest.php
@@ -129,8 +129,8 @@ class ValidatorTest extends TestCase
         $validator = new ResetPasswordValidator();
         $data = $validator -> escape(
             [
-                'pwdnew' => 'NewPassword123',
-                'pwdverif' => 'NewPassword123'
+                'pwdnew' => 'NewPassword123@!',
+                'pwdverif' => 'NewPassword123@!'
             ]
         );
 

--- a/App/tests/Unit/Validator/ValidatorTest.php
+++ b/App/tests/Unit/Validator/ValidatorTest.php
@@ -141,13 +141,13 @@ class ValidatorTest extends TestCase
     public function resetPasswordValidatorRejectsShortPassword(): void
     {
         $this -> expectException(ExceptionValidationResetPassword:: class);
-        $this -> expectExceptionMessage('au moins 8 caractères');
+        $this -> expectExceptionMessage('Obligation de 12 caractères minimum');
 
         $validator = new ResetPasswordValidator();
         $data = $validator -> escape(
             [
-                'pwdnew' => 'short',
-                'pwdverif' => 'short'
+                'pwdnew' => 'Short123!',
+                'pwdverif' => 'Short123!'
             ]
         );
 
@@ -163,8 +163,8 @@ class ValidatorTest extends TestCase
         $validator = new ResetPasswordValidator();
         $data = $validator -> escape(
             [
-                'pwdnew' => 'Password123',
-                'pwdverif' => 'DifferentPassword123'
+                'pwdnew' => 'P@ssword2026!',
+                'pwdverif' => 'DifferentP@ssword2026!'
             ]
         );
 
@@ -191,12 +191,10 @@ class ValidatorTest extends TestCase
     public static function validPasswordsProvider(): array
     {
         return [
-            'exactly_8_chars' => ['12345678'],
-            'with_special' => ['P@ssw0rd!'],
-            'long_password' => ['ThisIsAVeryLongPasswordWithMoreThan20Characters'],
-            'with_spaces' => ['My Pass Word 123'],
-            'numbers_only' => ['12345678'],
-            'mixed_case' => ['AbCdEfGh']
+            'exactly_12_chars' => ['Password123!'],
+            'with_special' => ['P@ssw0rd2026!'],
+            'long_password' => ['ThisIsAVeryLongPasswordWithMoreThan20Characters1!'],
+            'with_spaces' => ['My P@ss Word 123']
         ];
     }
 
@@ -502,8 +500,8 @@ class ValidatorTest extends TestCase
 
         $data = $validator -> escape(
             [
-                'pwdnew' => 'Pàsswørd123',
-                'pwdverif' => 'Pàsswørd123'
+                'pwdnew' => 'Pàsswørd1234!',
+                'pwdverif' => 'Pàsswørd1234!'
             ]
         );
 


### PR DESCRIPTION
Tighten password policy: FormValidator::isValidPassword now requires a minimum of 12 characters and enforces at least one uppercase, one lowercase, one digit and one special character. Update ResetPasswordValidator error text and adjust registration/reset HTML inputs to minlength="12" and explanatory text. Update unit tests and fixtures to use compliant passwords and to expect the new error message/providers.